### PR TITLE
Adds API function to disable scroll/wheel observation

### DIFF
--- a/event-infinite-scroll.html
+++ b/event-infinite-scroll.html
@@ -116,6 +116,15 @@ It will raise event when it reaches.
             });
         },
 
+        stopObserve: function () {
+            this.parentNode.removeEventListener("scroll");
+            this.parentNode.removeEventListener("mousewheel");
+
+            if (this.observer) {
+                this.observer.disconnect();
+            }
+        },
+
         scrolledWheel: function () {
             if ( this.parentNode.scrollHeight == this.parentNode.clientHeight ) {
                 this.scrolled();


### PR DESCRIPTION
It would be nice to disable observation. I'm using paper-tabs/iron-pages and I was trying to add infinite scrolling on one page only. 
